### PR TITLE
pypodman: add options to handle ssh host keys

### DIFF
--- a/podman/podman/client.py
+++ b/podman/podman/client.py
@@ -46,7 +46,7 @@ class BaseClient():
             raise ValueError('interface is required and cannot be None')
 
         unsupported = set(kwargs.keys()).difference(
-            ('uri', 'interface', 'remote_uri', 'identity_file'))
+            ('uri', 'interface', 'remote_uri', 'identity_file', 'ignore_hosts', 'known_hosts'))
         if unsupported:
             raise ValueError('Unknown keyword arguments: {}'.format(
                 ', '.join(unsupported)))
@@ -84,6 +84,8 @@ class BaseClient():
                 remote.hostname,
                 remote.port,
                 kwargs.get('identity_file'),
+                kwargs.get('ignore_hosts'),
+                kwargs.get('known_hosts'),
             ))
 
 

--- a/podman/podman/libs/tunnel.py
+++ b/podman/podman/libs/tunnel.py
@@ -20,6 +20,8 @@ Context = collections.namedtuple('Context', (
     'hostname',
     'port',
     'identity_file',
+    'ignore_hosts',
+    'known_hosts',
 ))
 Context.__new__.__defaults__ = (None, ) * len(Context._fields)
 
@@ -120,6 +122,13 @@ class Tunnel():
 
         cmd.extend(('-L', '{}:{}'.format(self.context.local_socket,
                                          self.context.remote_socket)))
+
+        if self.context.ignore_hosts:
+            cmd.extend(('-o', 'StrictHostKeyChecking=no',
+                        '-o', 'UserKnownHostsFile=/dev/null'))
+        elif self.context.known_hosts:
+            cmd.extend(('-o', 'UserKnownHostsFile=%s' % self.context.known_hosts))
+
         if self.context.identity_file:
             cmd.extend(('-i', self.context.identity_file))
 

--- a/pypodman/pypodman/lib/action_base.py
+++ b/pypodman/pypodman/lib/action_base.py
@@ -58,6 +58,16 @@ class AbstractActionBase(abc.ABC):
         return self._args.identity_file
 
     @property
+    def ignore_hosts(self):
+        """Ignore ssh host keys."""
+        return self._args.ignore_hosts
+
+    @property
+    def known_hosts(self):
+        """File for known hosts."""
+        return self._args.known_hosts
+
+    @property
     @lru_cache(maxsize=1)
     def client(self):
         """Podman remote client for communicating."""
@@ -66,14 +76,18 @@ class AbstractActionBase(abc.ABC):
         return podman.Client(
             uri=self.local_uri,
             remote_uri=self.remote_uri,
-            identity_file=self.identity_file)
+            identity_file=self.identity_file,
+            ignore_hosts=self.ignore_hosts,
+            known_hosts=self.known_hosts)
 
     def __repr__(self):
         """Compute the “official” string representation of object."""
         return ("{}(local_uri='{}', remote_uri='{}',"
-                " identity_file='{}')").format(
+                " identity_file='{}', ignore_hosts='{}', known_hosts='{}')").format(
                     self.__class__,
                     self.local_uri,
                     self.remote_uri,
                     self.identity_file,
+                    self.ignore_hosts,
+                    self.known_hosts,
                 )

--- a/pypodman/pypodman/lib/podman_parser.py
+++ b/pypodman/pypodman/lib/podman_parser.py
@@ -101,6 +101,15 @@ class PodmanArgumentParser(argparse.ArgumentParser):
             action=PathAction,
             help='path to ssh identity file. (default: ~user/.ssh/id_dsa)')
         self.add_argument(
+            '--ignore-hosts',
+            action='store_true',
+            help='ignore ssh host keys (default: False)')
+        self.add_argument(
+            '--known-hosts',
+            '-k',
+            action=PathAction,
+            help='path to ssh known hosts. (default: ~user/.ssh/known_hosts)')
+        self.add_argument(
             '--config-home',
             metavar='DIRECTORY',
             action=PathAction,
@@ -224,6 +233,27 @@ class PodmanArgumentParser(argparse.ArgumentParser):
 
         if not os.path.isfile(args.identity_file):
             args.identity_file = None
+
+        setattr(
+            args,
+            'ignore_hosts',
+            getattr(args, 'ignore_hosts')
+            or os.environ.get('PODMAN_IGNORE_HOSTS')
+            or config['default'].get('ignore_hosts')
+            or False
+        )   # yapf:disable
+
+        setattr(
+            args,
+            'known_hosts',
+            getattr(args, 'known_hosts')
+            or os.environ.get('PODMAN_KNOWN_HOSTS')
+            or config['default'].get('known_hosts')
+            or os.path.expanduser('~{}/.ssh/known_hosts'.format(args.username))
+        )   # yapf:disable
+
+        if not os.path.isfile(args.known_hosts):
+            args.known_hosts = None
 
         if args.host:
             args.local_socket_path = str(Path(args.run_dir, 'podman.socket'))


### PR DESCRIPTION
One option to ignore checking host keys altogether.

And one to override the location of "known_hosts".


Moved from https://github.com/containers/libpod/pull/1825