### PR TITLE
Introduce travis-ci and autodeployments on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+dist: xenial
+language: python
+cache:
+- pip
+python:
+- '3.4'
+- '3.5'
+- '3.6'
+before_install:
+- pip install -U pip
+- pip install -U setuptools
+- pip install -U wheel
+install:
+- pip install tox-travis .[devel]
+script:
+- echo "test"
+deploy:
+  - provider: pypi
+    user: containers-libpod
+    password: fake-password
+    on:
+      tags: true
+    distributions: sdist bdist_wheel


### PR DESCRIPTION
Introduce travis-ci:
- deploy on pypi on git tag push on github

These changes doesn't activate tox to let's the time to find a way to execute it by using|not using sudo.