### PR TITLE
Pull image function throws KeyError for id

### DIFF
--- a/podman/libs/images.py
+++ b/podman/libs/images.py
@@ -148,7 +148,7 @@ class Images():
         """Copy image from registry to image store."""
         with self._client() as podman:
             results = podman.PullImage(source)
-        return results['id']
+        return results['reply']['id']
 
     def search(self, id_, limit=25):
         """Search registries for id."""


### PR DESCRIPTION
Pull image function ```pull(self, source)```for Python podman throws
following error as the function tries to returns `id` from `results`
by calling `results['id]`.

```
Traceback (most recent call last):
  File "sdk.py", line 6, in <module>
    print(client.images.pull('fedora:latest'))
  File "/root/.local/lib/python3.7/site-packages/podman-1.3.1-py3.7.egg/podman/libs/images.py", line 151, in pull
KeyError: 'id'
```

This PR resolves https://github.com/containers/python-podman/issues/30

`id` should instead be fetched from `reply` in `result`.

Signed-off-by: Dhanisha Phadate <phadate.d@husky.neu.edu>