### PR TITLE
Fix pypi deployment by using documentation at markdown format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,18 @@ before_install:
 - pip install -U pip
 - pip install -U setuptools
 - pip install -U wheel
+- pip install -U twine
 install:
 - pip install tox-travis .[devel]
 script:
-- echo "test"
+- pip install -U setuptools
+- pip install -U wheel
+- pip install -U twine
+- pip list
+- rm -rf dist
+- python setup.py sdist
+- python setup.py bdist_wheel
+- twine check dist/*
 deploy:
   - provider: pypi
     user: containers-libpod

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+Anders F Björklund <anders.f.bjorklund@gmail.com>
+Brent Baude <bbaude@redhat.com>
+Daniel J Walsh <dwalsh@redhat.com>
+Dhanisha Phadate <phadate.d@husky.neu.edu>
+Hervé Beraud <hberaud@redhat.com>
+Jhon Honce <jhonce@redhat.com>
+Jhon Honce <jwhonce@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,27 @@
+CHANGES
+=======
+
+* Fix pypi deployment by using documentation at markdown format
+
+v0.0.2
+------
+
+* Fix up pushing to pypi
+
+v0.0.1
+------
+
+* Pull image function throws KeyError for id
+* Secure Travis
+* Introduce travis-ci and autodeployments on tags
+* Improve packaging by using PBR
+* Add base requirements to README.md
+* Remove pypodman to python-pypodman repo
+* Update module to align with varlink API changes
+* Use GetVersion instead of Ping, as recommended
+* Improve README
+* pypodman: add options to handle ssh host keys
+* Update README.md
+* add missing bits
+* Initial copy from containers/libpod
+* Initial commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,25 +1,28 @@
 [metadata]
 name = podman
 home-page = https://github.com/containers/python-podman
+summary = A library to interact with a Podman server
+description-file =
+    README.md
+    ChangeLog
+    AUTHORS
+author = Jhon Honce
+long_description_content_type = text/markdown
+author_email = jhonce@redhat.com
+license = Apache Software License
 project_urls =
     Bug Tracker = https://github.com/containers/python-podman/issues
     Source Code = https://github.com/containers/python-podman
-summary = A library to interact with a Podman server
-description_file = README.md
-description_content_type = text/markdown
-author = Jhon Honce
-author_email = jhonce@redhat.com
-license = Apache Software License
 classifier =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3.4
     Topic :: Software Development
-keywords =
-    varlink
-    libpod
-    podman
+keywords = varlink, libpod, podman
+requires-dist =
+    setuptools
+    wheel
 
 [files]
 packages =
@@ -32,5 +35,5 @@ devel=
     tox
     bandit
 
-[wheel]
+[bdist_wheel]
 universal = 1


### PR DESCRIPTION
podman README.md is markdown file who is used as a long description
so we need to specify to pypi to use markdown parser to properly
upload package

https://pypi.org/help/#description-content-type