### PR TITLE
Stop to support python 3.4 introduce python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 cache:
 - pip
 python:
+- '3.7'
 - '3.6'
 - '3.5'
 - '3.4'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # podman - pythonic library for working with varlink interface to Podman
 
+[![Build Status](https://travis-ci.org/containers/python-podman.svg?branch=master)](https://travis-ci.org/containers/python-podman)
+![PyPI](https://img.shields.io/pypi/v/podman.svg)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/podman.svg)
+![PyPI - Status](https://img.shields.io/pypi/status/podman.svg)
+
 ## Status: Active Development
 
 See [libpod](https://github.com/containers/python-podman)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ classifier =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Software Development
 keywords =
     varlink


### PR DESCRIPTION
The README say that podman require python 3.5+ so:
- introduce python 3.7 on CI
- remove python 3.4 support on CI
- adapt the python classifier to inform user of supported version
- introduce some badges on README to inform user of package info