### PR TITLE
[fix] add pbr to requirements 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ psutil
 python-dateutil
 setuptools>=39
 varlink
+pbr


### PR DESCRIPTION
Traceback while importing podman

Python 3.7.4 (default, Jul  9 2019, 16:32:37) 
[GCC 9.1.1 20190503 (Red Hat 9.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import podman
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vikasmulaje/contribution/podman/python-podman/podman/__init__.py", line 8, in <module>
    from pbr.version import VersionInfo
ModuleNotFoundError: No module named 'pbr'
