### PR TITLE
Introduce mocked unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - python setup.py bdist_wheel
   - twine check dist/*
   # Execture tests
-  - tox -e pep8
+  - tox
 deploy:
   - provider: pypi
     user: containers-libpod

--- a/tests/libs/test_pod.py
+++ b/tests/libs/test_pod.py
@@ -1,0 +1,87 @@
+import unittest
+from varlink import mock
+import varlink
+
+import podman
+from podman.libs.pods import Pod
+
+
+pod_id_1 = "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+short_pod_id_1 = "135d71b9495f"
+pod_id_2 = "49a5cce72093a5ca47c6de86f10ad7bb36391e2d89cef765f807e460865a0ec6"
+short_pod_id_2 = "49a5cce72093"
+pods = {
+    short_pod_id_1: pod_id_1,
+    short_pod_id_2: pod_id_2,
+}
+
+types = """
+type ListPodData (
+    id: string,
+    name: string,
+    createdat: string,
+    cgroup: string,
+    status: string,
+    labels: [string]string,
+    numberofcontainers: string,
+    containersinfo: []ListPodContainerInfo
+)
+
+type ListPodContainerInfo (
+    name: string,
+    id: string,
+    status: string
+)
+"""
+
+
+class ServicePod():
+
+    def StartPod(self, name: str) -> str:
+        """return pod"""
+        return {
+            "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+        }
+
+    def GetPod(self, name: str) -> str:
+        """return pod: ListPodData"""
+        return  {
+            "pod": {
+                "cgroup": "machine.slice",
+                "containersinfo": [
+                  {
+                    "id": "1840835294cf076a822e4e12ba4152411f131bd869e7f6a4e8b16df9b0ea5c7f",
+                    "name": "1840835294cf-infra",
+                    "status": "running"
+                  },
+                  {
+                    "id": "49a5cce72093a5ca47c6de86f10ad7bb36391e2d89cef765f807e460865a0ec6",
+                    "name": "upbeat_murdock",
+                    "status": "running"
+                  }
+                ],
+                "createdat": "2018-12-07 13:10:15.014139258 -0600 CST",
+                "id": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6",
+                "name": "foobar",
+                "numberofcontainers": "2",
+                "status": "Running"
+            }
+        }
+
+    def GetVersion(self) -> str:
+        """return version"""
+        return {"version": "testing"}
+
+
+class TestPod(unittest.TestCase):
+
+    @mock.mockedservice(
+        fake_service=ServicePod,
+        fake_types=types,
+        name='io.podman',
+        address='unix:@podmantests'
+    )
+    def test_start(self):
+        client = podman.Client(uri="unix:@podmantests")
+        pod = Pod(client._client, short_pod_id_1, {"foo": "bar"})
+        self.assertEqual(pod.start()["numberofcontainers"], "2")

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ usedevelop = True
 install_command = pip install {opts} {packages}
 deps =
   -r{toxinidir}/test-requirements.txt
+  -r{toxinidir}/requirements.txt
 whitelist_externals = bash
-commands=bash test/test_runner.sh
+commands=python -m unittest discover tests/
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
To simplify testing and avoid to install libpod for testing
I've introduced some mocking features on varlink:

https://github.com/varlink/python/commit/e736c6636ef11987d868e997cdcce743d6164954

These changes introduces podman unit tests based on the varlink mocking features
to avoid to use libpod locally and on CI.

Unit tests are focused on python-podman and don't want to retest libpod.

Also start to launch unit tests from travis.

**These changes are related to https://github.com/varlink/python/pull/17 so we need to wait that these changes will be merged. In other words we need they changes first. The CI error is expected until we https://github.com/varlink/python/pull/17 isn't merged.**

We can plan in a second time to synchronize changes on https://github.com/containers/libpod/blob/auto/cmd/podman/varlink/io.podman.varlink and interface definition with our testing suit there or something like that to always match the right interfaces versions.