### PR TITLE
Remove unussed argument

### DIFF
--- a/podman/client.py
+++ b/podman/client.py
@@ -33,7 +33,6 @@ class BaseClient():
     def factory(cls,
                 uri=None,
                 interface='io.podman',
-                *args,
                 **kwargs):
         """Construct a Client based on input."""
         log_level = os.environ.get('LOG_LEVEL')


### PR DESCRIPTION
The `factory` function can accept a variable number of arguments via the `*args`  python idiom, but the funtion is only using the parameters specified in the form of a dictionary with `** kwargs`.


I think it is healthier to remove the unused variable from the definition of the function.

Signed-off-by: William José Moreno Reyes <williamjmorenor@gmail.com>