### PR TITLE
Fixed podman link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Status: Active Development
 
-See [libpod](https://github.com/containers/python-podman)
+See [libpod](https://github.com/containers/libpod)
 
 ## Overview
 


### PR DESCRIPTION
The libpod link pointed to the same repository. This fixes it.