### PR TITLE
Synchronize with libpod 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ script:
   - twine check dist/*
   # Execture tests
   - tox
+  # While many deltas exists between python-podman version and libpod version
+  # we ask to synchronize.sh to don't exit "1" to avoid to get lot of
+  # well know issues, in other word we will only display errors in CI job log
+  # but we will consider that everything work fine with that.
+  - ./tools/synchronize.sh --ignore
 deploy:
   - provider: pypi
     user: containers-libpod

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - '3.7'
   - '3.6'
   - '3.5'
-  - '3.4'
 before_install:
   - pip install -U pip
   - pip install -U setuptools

--- a/podman/libs/images.py
+++ b/podman/libs/images.py
@@ -115,6 +115,13 @@ class Image(collections.UserDict):
             results = podman.TagImage(self._id, tag)
         return results["image"]
 
+    def save(self, output, format_type="oci-archive"):
+        """Save the image from the local image storage to a tarball."""
+        options = {'Name': self._id, 'Output': output, 'Format': format_type}
+        with self._client() as podman:
+            results = podman.ImageSave(options)
+        return results["reply"]
+
 
 class Images:
     """Model for Images collection."""
@@ -255,3 +262,23 @@ class Images:
         with self._client() as podman:
             result = podman.GetImage(id_)
         return Image(self._client, result["image"]["id"], result["image"])
+
+    def exists(self, id_):
+        """Returns a bool as to whether the image exists in local storage."""
+        with self._client() as podman:
+            exist = podman.ImageExists(id_)
+            if exist['exists'] == 0:
+                return True
+        return False
+
+    def prune(self, all=True, filter=[]):
+        """Removes all unused images from the local store."""
+        with self._client() as podman:
+            results = podman.ImagesPrune(all, filter)
+        return results['pruned']
+
+    def load(self, id_, inputFile, quiet, deleteFile):
+        """Load an image into local storage from a tarball."""
+        with self._client() as podman:
+            results = podman.LoadImage(id_, inputFile, quiet, deleteFile)
+        return results['reply']

--- a/podman/libs/pods.py
+++ b/podman/libs/pods.py
@@ -115,6 +115,18 @@ class Pod(collections.UserDict):
             podman.UnpausePod(self._ident)
             return self._refresh(podman)
 
+    def generate_kub(self, service=True):
+        """Generates a Kubernetes v1 Pod description of a Podman container"""
+        with self._client() as podman:
+            results = podman.GenerateKube(self._ident, service)
+        return results['pod']
+
+    def state_data(self):
+        """Returns the container's state config in string form."""
+        with self._client() as podman:
+            results = podman.PodStateData(self._id)
+        return results['config']
+
 
 class Pods():
     """Model for accessing pods."""
@@ -153,5 +165,19 @@ class Pods():
         """List all pods."""
         with self._client() as podman:
             results = podman.ListPods()
+        for pod in results['pods']:
+            yield Pod(self._client, pod['id'], pod)
+
+    def get_by_status(self, statuses):
+        """Get pods by statuses"""
+        with self._client() as podman:
+            results = podman.GetPodsByStatus(statuses)
+        return results['containers']
+
+    def get_by_context(self, all=True, latest=False, args=[]):
+        """Get pods ids or names depending on all, latest, or a list of
+        pods names"""
+        with self._client() as podman:
+            results = podman.GetPodsByContext(all, latest, args)
         for pod in results['pods']:
             yield Pod(self._client, pod['id'], pod)

--- a/podman/libs/system.py
+++ b/podman/libs/system.py
@@ -38,3 +38,15 @@ class System():
         with self._client() as podman:
             response = podman.GetVersion()
         return 'version' in response
+
+    def receive_file(self, path, delete=True):
+        """Allows the host to send a remote client a file."""
+        with self._client() as podman:
+            response = podman.ReceiveFile(path, delete)
+        return response['len']
+
+    def get_events(self, filters=[], since=None, until=None):
+        """Returns known libpod events filtered by the options provided."""
+        with self._client() as podman:
+            response = podman.GetEvent(filters, since, until)
+        return response['events']

--- a/podman/libs/volumes.py
+++ b/podman/libs/volumes.py
@@ -1,0 +1,33 @@
+"""Models for manipulating containers and storage."""
+
+
+class Volumes():
+    """Model for Volumes collection."""
+
+    def __init__(self, client):
+        """Construct model for Volume collection."""
+        self._client = client
+
+    def create(self, options):
+        """Creates a volume on a remote host."""
+        with self._client() as podman:
+            results = podman.VolumeCreate(options)
+        return results['volumeName']
+
+    def remove(self, options):
+        """Remove a volume on a remote host."""
+        with self._client() as podman:
+            results = podman.VolumeRemove(options)
+        return results['successes'], results['failures']
+
+    def get(self, args, all=True):
+        """Gets slice of the volumes on a remote host."""
+        with self._client() as podman:
+            results = podman.GetVolumes(args, all)
+        return results['volumes']
+
+    def prunes(self):
+        """Removes unused volumes on the host."""
+        with self._client() as podman:
+            results = podman.VolumesPrune()
+        return results['prunedNames'], results['prunedErrors']

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,16 @@ license = Apache Software License
 project_urls =
     Bug Tracker = https://github.com/containers/python-podman/issues
     Source Code = https://github.com/containers/python-podman
+python-requires = >=3.5
 classifier =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 keywords = varlink, libpod, podman
 requires-dist =
@@ -37,6 +39,3 @@ devel=
     pbr
     tox
     bandit
-
-[bdist_wheel]
-universal = 1

--- a/tools/synchronize.sh
+++ b/tools/synchronize.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+
+function help {
+# Display helping message
+cat <<EOF
+usage: $0 [<args>]
+
+Compare python-podman implemention of the libpod varlink interface
+
+Arguments:
+    -b, --branch   The libpod branch or commit ID to compare with (default: master)
+    -d, --debug    Turn on the debug mode
+examples:
+    $0 --branch=master
+EOF
+}
+
+function clean {
+    if [ -f ${LOCAL_INTERFACE_FILE} ]; then
+        rm ${LOCAL_INTERFACE_FILE}
+    fi
+}
+
+function download {
+    echo "Downloading the libpod's defined interface"
+    url=${LIBPOD_RAW_URL}/${BRANCH}/${INTERFACE}
+    echo ${url}
+    curl ${url} -o ${LOCAL_INTERFACE_FILE}
+}
+
+function extract {
+    cat ${LOCAL_INTERFACE_FILE} | \
+        grep "method" | \
+        grep -v "^#" | \
+        awk '{print $2}' | \
+        awk -F "(" '{print $1}'
+}
+
+function compare {
+    for method in $(extract)
+    do
+        grep -ri podman -e "${method}" &>/dev/null;
+        if [ $? != 0 ]; then
+            echo -e "Method ${method} seems not yet implemented"
+        fi
+    done
+}
+
+BRANCH="master"
+IGNORE_ERRORS=false
+# Parse command line user inputs
+for i in "$@"
+do
+    case $i in
+        # The host to use
+        -b=*|--branch=*)
+        BRANCH="${i#*=}"
+        shift 1
+        ;;
+        # Ignore error
+        -i|--ignore)
+        IGNORE_ERRORS=true
+        shift 1
+        ;;
+        # Turn on the debug mode
+        -d|--debug)
+        set -x
+        shift 1
+        ;;
+        # Display the helping message
+        -h|--help)
+        help
+        exit 0
+        ;;
+    esac
+done
+
+EXIT_CODE=0
+LIBPOD_REPO=containers/libpod
+INTERFACE=cmd/podman/varlink/io.podman.varlink
+LOCAL_INTERFACE_FILE=/tmp/$(basename ${INTERFACE})
+LIBPOD_RAW_URL=https://raw.githubusercontent.com/${LIBPOD_REPO}
+
+clean
+download
+result=$(compare)
+echo -e "${result}"
+if [ ! -z "${result}" ]; then
+    echo "$(echo -e "${result}" | wc -l) error(s) found"
+    if [ ${IGNORE_ERRORS} = true ]; then
+        echo "You asked to ignore errors so This script will return status 0"
+    else
+        EXIT_CODE=1
+    fi
+else
+    echo "libpod and python-podman seems properly synchronized"
+fi
+clean
+
+echo "Comparison finished...bye!"
+exit ${EXIT_CODE}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35,36,37},pep8
+envlist = py{35,36,37},pep8
 skipdist = True
 
 [testenv]


### PR DESCRIPTION
Make python-podman compatible with libpod 1.6.1
    
libpod 1.6.1 is revision is f3ffda1e08f19e9a6a88484136b5eed76533f21a
    
Get diff with:
    
```
$ ./tools/synchronize.sh -b=f3ffda1e08f19e9a6a88484136b5eed76533f21a -i
```

For more infos about this previous command please see #71 
    
Introducing:

- GetContainersByStatus
- HealthCheckRun
- GetContainersByContext
- GetContainersLogs
- GetContainerStatsWithHistory
- InitContainer
- AttachControl
- GetPodsByStatus
- ImageExists
- ContainerExists
- ContainerCheckpoint
- ContainerRestore
- ContainerRunlabel
- ExecContainer
- ListContainerMounts
- MountContainer
- UnmountContainer
- ImagesPrune
- GenerateKube
- ContainerConfig
- ContainerArtifacts
- ContainerInspectData
- ContainerStateData
- PodStateData
- CreateFromCC
- ReceiveFile
- VolumeCreate
- VolumeRemove
- GetVolumes
- VolumesPrune
- ImageSave
- GetPodsByContext
- LoadImage
- GetEvents
- GetLayersMapWithImageInfo
- BuildImageHierarchyMap

Some methods are for the development of Podman and should not be used.

List of ignored and not implemented methods:
- CreateFromCC
- GetLayersMapWithImageInfo
- BuildImageHierarchyMap

When these changes will be merged then we need to release a new python-podman version 1.6.1:

```
$ git tag 1.6.1
$ git push --tags
$ # The previous command will launch the CI who will generate and publish the release 1.6.1 on pypi
```
When these changes will be merged and the tag published then I will do the same things for higher version (1.6.2, 1.6.3, etc... 1.7.0), to ensure that will only release the right delta between versions.

