### PR TITLE
Drop py34 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - '3.7'
   - '3.6'
   - '3.5'
-  - '3.4'
 before_install:
   - pip install -U pip
   - pip install -U setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,16 @@ license = Apache Software License
 project_urls =
     Bug Tracker = https://github.com/containers/python-podman/issues
     Source Code = https://github.com/containers/python-podman
+python-requires = >=3.5
 classifier =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 keywords = varlink, libpod, podman
 requires-dist =
@@ -37,6 +39,3 @@ devel=
     pbr
     tox
     bandit
-
-[bdist_wheel]
-universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35,36,37},pep8
+envlist = py{35,36,37},pep8
 skipdist = True
 
 [testenv]


### PR DESCRIPTION
RHEL8 as the minimal version will be required for python-podman.

Also introduce some new pypi classifiers, set a minimal version in
setup.cfg, and stop to build universal wheel.