### PR TITLE
add try logic for command key lookup

### DIFF
--- a/podman/libs/images.py
+++ b/podman/libs/images.py
@@ -51,7 +51,11 @@ class Image(collections.UserDict):
         # TODO: Are these settings still required?
         config["net_mode"] = "bridge"
         config["network"] = "bridge"
-        config["args"] = flatten([config["image"], config["command"]])
+        
+        try:
+            config['args'] = flatten([config['image'], config['command']])
+        except KeyError:
+            config['args'] = flatten([config['image']])
 
         logging.debug("Image %s: create config: %s", self._id, config)
         with self._client() as podman:


### PR DESCRIPTION
when the container image being used already has a command specified the pre-existing behaviour was to add whatever was specified as an additional argument to the existing command spec.

Currently the following scenarios occur:
`img.create(detach=True, tty=True, privileged=True, name='testing')`  <-- Results in key error (command arg is missing)
`img.create(detach=True, tty=True, privileged=True, name='testing', command='')`  <-- Results in second item being added to command list (much like the following snippet from the dictionary returned from img.create `'command': ['command_specified_by_Dockerfile', '']`)

This can break command entry points that aren't setup (or don't understand) additional args.

Since many container images already have the command specified, we can make the command argument optional so that it only has to be used if required by the user.